### PR TITLE
keep in-memory server state across rebuilds

### DIFF
--- a/app/data.ts
+++ b/app/data.ts
@@ -22,10 +22,18 @@ export type ContactRecord = ContactMutation & {
   createdAt: string;
 };
 
+// https://remix.run/docs/en/main/guides/manual-mode#keeping-in-memory-server-state-across-rebuilds
+function remember<T>(key: string, getValue: () => T): T {
+  const g = global as any;
+  g.__remember ??= {};
+  g.__remember[key] ??= getValue();
+  return g.__remember[key];
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // This is just a fake DB table. In a real app you'd be talking to a real db or
 // fetching from an existing API.
-const fakeContacts = {
+const fakeContacts = remember("fakeContacts", () => ({
   records: {} as Record<string, ContactRecord>,
 
   async getAll(): Promise<ContactRecord[]> {
@@ -58,7 +66,7 @@ const fakeContacts = {
     delete fakeContacts.records[id];
     return null;
   },
-};
+}));
 
 ////////////////////////////////////////////////////////////////////////////////
 // Handful of helper functions to be called from route loaders and actions

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev",
+    "dev": "remix dev --manual",
     "start": "remix-serve build",
     "typecheck": "tsc"
   },


### PR DESCRIPTION
Let's hold off on this until after v2 lands since `remix-serve` would need some improvements

---

`--manual` + `remember` util so that in-memory data sticks around

## TODO

- [ ] run through the tutorial with this template to make sure everything works
- [ ] fix `remix-serve` so that `remix dev --manual` works ootb when `cjs` is the server format
- [ ] docs PR for `remix-serve` in manual mode