### PR TITLE
Override object-path version to a higher (secure) version than allowed by sort-by

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "overrides": {
+    "object-path": "^0.11.8"
   }
 }


### PR DESCRIPTION
This template depends on the `sort-by` package, but that package depends on a pinned version of `object-path` that has 3 disclosed security vulnerabilities. A [pull request to raise and loosen the constraint](https://github.com/kvnneff/sort-by/pull/16) in the `sort-by` package has not been merged for over a year.

Currently, `npm audit fix --force` lowers the `sort-by` version rather than raising the `object-path` version.

Here's a PR to raise the `object-path` version instead.

While this PR is a stop-gap, perhaps a better fix would be to change this tutorial to replace `sort-by` with a more actively maintained library? Lodash has a sortBy() method, though I don't know if that provides the functionality that this tutorial needs.
